### PR TITLE
Remove command-t and replace with fzf

### DIFF
--- a/update_bundles.rb
+++ b/update_bundles.rb
@@ -15,7 +15,6 @@ git_bundles = [
   "http://github.com/tpope/vim-surround.git",
   "http://github.com/tpope/vim-vividchalk.git",
   "http://github.com/vim-ruby/vim-ruby.git",
-  "http://github.com/wincent/Command-T.git",
   "http://github.com/greyblake/vim-preview.git",
   "http://github.com/mileszs/ack.vim.git",
   "http://github.com/altercation/vim-colors-solarized.git",
@@ -45,13 +44,6 @@ git_bundles = [
 require 'fileutils'
 require 'open-uri'
 
-def command_t(dir)
-  FileUtils.cd(dir)
-  puts "making command-t"
-  puts `rake make`
-  FileUtils.cd('..')
-end
-
 def vim_preview
   gems = [
     "bluecloth",
@@ -76,7 +68,6 @@ git_bundles.each do |url|
   puts "unpacking #{url} into #{dir}"
   `git clone #{url} #{dir}`
   FileUtils.rm_rf(File.join(dir, ".git"))
-  command_t dir if dir=="command-t"
   vim_preview if dir=="vim-preview"
 end
 

--- a/vimrc
+++ b/vimrc
@@ -65,29 +65,6 @@ noremap   <Right>  <NOP>
 " Set tags for vim-fugitive
 set tags^=.git/tags
 
-" Command T
-" ignore files to make list load faster
-set wildignore+=tmp,.tags
-set wildignore+=*.gif,*.jpg,*.png,*.cache
-" ignore images in rails applications
-set wildignore+=public/images
-" ignore vendored files in rails applications
-set wildignore+=vendor
-
-" change local directory to current file so command-t lists relevant files
-map <leader>c :lcd %:p:h
-" refresh command-t so it sees new files and deletes
-map <leader>ctf :CommandTFlush
-" Here we are trying to get the arrow keys to work when using CommandT in TMux
-map <Esc>[A <Up>
-map <Esc>[B <Down>
-map <Esc>[C <Right>
-map <Esc>[D <Left>
-
-" Try and stop CommandT looking outside project root folder 
-let g:CommandTTraverseSCM = 'pwd'
-let g:CommandTFileScanner = 'find'
-
 " Use netrw to preview files in a directory
 let g:netrw_preview = 1 "preview in vertical split"
 let g:netrw_winsize = 0
@@ -222,6 +199,9 @@ endfunction
 source ~/.vim/.gbernhardt_tests
 source ~/.vim/.vimwiki
 
+" Command-T replacement FZF
+set rtp+=/usr/local/opt/fzf
+nmap <leader>t  :FZF<CR>
 
 function! Prose()
   Goyo


### PR DESCRIPTION
- remove Command-T from bundles
- remove from update_bundles.rb script
- remove entries in vimrc
- add FZF entries to vimrc

Thankyou command-t for your service, but the ruby version c compiling
issue has just become to much to bear.